### PR TITLE
dependabot -> developへのPR時の動作検証 （develop-20230404 が存在する場合）

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       # プルリクエストのbaseブランチを変更する
       - name: Run GitHub API
         run: |
-          BRANCH_NAME="${{ steps.branch_exists.outputs.branch_name }}"
+          BRANCH_NAME="develop-$(TZ=Asia/Tokyo date +'%Y%m%d')"
           curl -X PATCH \
                 -H "Accept: application/vnd.github+json" \
                 -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \

--- a/index6.html
+++ b/index6.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## 前提条件
- `develop-20230404` ブランチが既に存在する

## 期待する動作
- `compare` ブランチ名に `dependabot` が含まれる場合に発火
- `develop-20230404` （develop-日付）のようなブランチを新規作成・プッシュ
※すでに同名のブランチが存在する場合はスキップ
- `base` ブランチ `develop` -> `develop-20230404` に変更
- マージされる

## 備考
テストを通過済みの場合に発火される想定となります。

## `develop-20230404` ブランチが存在しない場合の動作検証
- [こちらのPR](https://github.com/h-yabi/github-actions-test2/pull/19)
